### PR TITLE
Remove minitest requirement

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -23,8 +23,6 @@ spec/spec_helper.rb:
 Gemfile:
   optional:
     ':system_tests':
-      - gem: 'minitest'
-        version: '< 5.19.0'
       - gem: 'voxpupuli-acceptance'
     ':release':
       - gem: 'puppet-blacksmith'

--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,6 @@ end
 group :system_tests do
   gem "puppet_litmus", '~> 1.0', require: false, platforms: [:ruby, :x64_mingw]
   gem "serverspec", '~> 2.41',   require: false
-  gem "minitest", '< 5.19.0',    require: false
   gem "voxpupuli-acceptance",    require: false
 end
 group :release do


### PR DESCRIPTION
[The bug](https://github.com/voxpupuli/beaker/pull/1819) was hopefully fixed in the latest beaker release (`5.3.1`).