### PR TITLE
Limit maximum memory usage for systemd service

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ fluentbit::outputs:
       port: 2021
 ```
 
+## Configuration
+
+
+Limit maximum memory usage per systemd unit:
+```yaml
+fluentbit::service_override_unit_file: true
+fluentbit::memory_max: 2G
+```
 
 ### Acceptance tests
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,6 +39,10 @@
 # @param service_override_unit_file
 #   Override service definition provided by package with a drop-in unit file.
 #
+# @param memory_max
+#   Limit memory usage for the systemd unit (requires `service_override_unit_file` set to `true`)
+#   Memory limit as a string with K, M, G or T suffix, e.g. `2G`
+#
 # @param manage_config_dir
 #   Whether to manage the configuration directory.
 #   When enabled, will remove all unmanaged files from the directory the
@@ -263,6 +267,7 @@ class fluentbit (
   Fluentbit::MultilineParser  $multiline_parsers = {},
   Fluentbit::Stream           $streams = {},
   Array[Stdlib::Absolutepath] $plugins = [],
+  Optional[String[1]]         $memory_max = undef,
 ) {
   $plugins_path = "${config_dir}/${plugins_dir}"
   $scripts_path = "${config_dir}/${scripts_dir}"

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -22,6 +22,7 @@ class fluentbit::service {
           {
             'binary_file' => $fluentbit::binary_file,
             'config_file' => $fluentbit::config_file,
+            'memory_max'  => $fluentbit::memory_max,
           }
         ),
       }

--- a/spec/classes/fluentbit_spec.rb
+++ b/spec/classes/fluentbit_spec.rb
@@ -161,4 +161,24 @@ describe 'fluentbit' do
               })
     }
   end
+
+  context 'with service memory limit' do
+    let(:params) do
+      {
+        service_override_unit_file: true,
+        memory_max: '2G',
+        manage_service: true,
+      }
+    end
+
+    it {
+      is_expected.to contain_service('fluent-bit')
+        .with_ensure('running')
+    }
+
+    it {
+      is_expected.to contain_systemd__unit_file('fluent-bit.service')
+        .with_content(%r{MemoryMax=2G})
+    }
+  end
 end

--- a/templates/fluentbit.service.epp
+++ b/templates/fluentbit.service.epp
@@ -11,6 +11,9 @@ EnvironmentFile=-/etc/default/fluent-bit
 ExecStart=<%= $binary_file %> -c <%= $config_file %> --enable-hot-reload
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=always
+<%- if $memory_max { -%>
+MemoryMax=<%= $memory_max %>
+<%- } -%>
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Support setting hard memory limit for `fluent-bit` service.