### PR TITLE
Support setting limit nofiles for systemd service

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ Limit maximum memory usage per systemd unit:
 fluentbit::service_override_unit_file: true
 fluentbit::memory_max: 2G
 ```
+You increase number of opened file descriptors for `fluent-bit.service`. Either by passing single value like `32768` (same soft and hard limit) or by setting both limits:
+```yaml
+limit_nofile: '8192:16384'
+```
 
 All Puppet variables are documented in [REFERENCE.md](./REFERENCE.md).
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -109,6 +109,7 @@ The following parameters are available in the `fluentbit` class:
 * [`service_ensure`](#-fluentbit--service_ensure)
 * [`service_name`](#-fluentbit--service_name)
 * [`restart_on_upgrade`](#-fluentbit--restart_on_upgrade)
+* [`limit_nofile`](#-fluentbit--limit_nofile)
 * [`manage_config_dir`](#-fluentbit--manage_config_dir)
 * [`manage_data_dir`](#-fluentbit--manage_data_dir)
 * [`inputs`](#-fluentbit--inputs)
@@ -366,16 +367,16 @@ Sets the primary transport layer protocol used by the asynchronous DNS resolver.
 
 Data type: `Optional[Stdlib::Absolutepath]`
 
-Absolute path where Fluent Bit will write its diagnostic logs.
-When specified, logs go to this file instead of syslog. 
-The file will be created by Fluent Bit automatically.
+Specify the absolute path to the log file for Fuent Bit service itself
+
+Default value: `undef`
 
 ##### <a name="-fluentbit--log_level"></a>`log_level`
 
 Data type: `Fluentbit::Loglevel`
 
 Set the logging verbosity level.
-Values are: error, info, debug and trace. Values are accumulative,
+Values are: off, error, warn, info, debug and trace. Values are accumulative,
 e.g: if 'debug' is set, it will include error, info and debug.
 Note that trace mode is only available if Fluent Bit was built with the WITH_TRACE option enabled.
 
@@ -525,6 +526,14 @@ Data type: `String[1]`
 Data type: `Boolean`
 
 
+
+##### <a name="-fluentbit--limit_nofile"></a>`limit_nofile`
+
+Data type: `Optional[Integer]`
+
+
+
+Default value: `undef`
 
 ##### <a name="-fluentbit--manage_config_dir"></a>`manage_config_dir`
 
@@ -816,7 +825,7 @@ Struct[{
 
 The Fluentbit::Loglevel data type.
 
-Alias of `Enum['error', 'warning', 'info', 'debug', 'trace']`
+Alias of `Enum['error', 'warn', 'info', 'debug', 'trace', 'off']`
 
 ### <a name="Fluentbit--MultilineParser"></a>`Fluentbit::MultilineParser`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -25,6 +25,7 @@
 * [`Fluentbit::Field_type`](#Fluentbit--Field_type)
 * [`Fluentbit::Loglevel`](#Fluentbit--Loglevel)
 * [`Fluentbit::MultilineParser`](#Fluentbit--MultilineParser)
+* [`Fluentbit::NoFileLimit`](#Fluentbit--NoFileLimit): systemd nofile limit, e.g 1024:4096 or simply 2048 (same soft and hard limit)
 * [`Fluentbit::Parser`](#Fluentbit--Parser)
 * [`Fluentbit::PipelinePlugin`](#Fluentbit--PipelinePlugin)
 * [`Fluentbit::PipelineType`](#Fluentbit--PipelineType)
@@ -109,13 +110,13 @@ The following parameters are available in the `fluentbit` class:
 * [`service_ensure`](#-fluentbit--service_ensure)
 * [`service_name`](#-fluentbit--service_name)
 * [`restart_on_upgrade`](#-fluentbit--restart_on_upgrade)
-* [`limit_nofile`](#-fluentbit--limit_nofile)
 * [`manage_config_dir`](#-fluentbit--manage_config_dir)
 * [`manage_data_dir`](#-fluentbit--manage_data_dir)
 * [`inputs`](#-fluentbit--inputs)
 * [`outputs`](#-fluentbit--outputs)
 * [`filters`](#-fluentbit--filters)
 * [`memory_max`](#-fluentbit--memory_max)
+* [`limit_nofile`](#-fluentbit--limit_nofile)
 
 ##### <a name="-fluentbit--manage_storage_dir"></a>`manage_storage_dir`
 
@@ -527,14 +528,6 @@ Data type: `Boolean`
 
 
 
-##### <a name="-fluentbit--limit_nofile"></a>`limit_nofile`
-
-Data type: `Optional[Integer]`
-
-
-
-Default value: `undef`
-
 ##### <a name="-fluentbit--manage_config_dir"></a>`manage_config_dir`
 
 Data type: `Boolean`
@@ -574,6 +567,14 @@ Default value: `{}`
 ##### <a name="-fluentbit--memory_max"></a>`memory_max`
 
 Data type: `Optional[String[1]]`
+
+
+
+Default value: `undef`
+
+##### <a name="-fluentbit--limit_nofile"></a>`limit_nofile`
+
+Data type: `Optional[Fluentbit::NoFileLimit]`
 
 
 
@@ -846,6 +847,12 @@ Hash[String, Struct[{
   Optional[flush_timeout] => Integer,
 }]]
 ```
+
+### <a name="Fluentbit--NoFileLimit"></a>`Fluentbit::NoFileLimit`
+
+systemd nofile limit, e.g 1024:4096 or simply 2048 (same soft and hard limit)
+
+Alias of `Variant[Integer[-1], Pattern['^(infinity|\d+(:(infinity|\d+))?)$']]`
 
 ### <a name="Fluentbit--Parser"></a>`Fluentbit::Parser`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -304,7 +304,7 @@ class fluentbit (
   Array[Stdlib::Absolutepath]      $plugins           = [],
   Optional[String[1]]              $memory_max        = undef,
   Optional[Stdlib::Absolutepath]   $log_file          = undef,
-  Optional[Integer]                $limit_nofile      = undef,
+  Optional[Fluentbit::NoFileLimit] $limit_nofile      = undef,
   Array[Stdlib::Absolutepath]      $includes          = [],
 ) {
   $pipelines_path = "${config_dir}/${pipelines_dir}"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,6 +54,9 @@
 #   Limit memory usage for the systemd unit (requires `service_override_unit_file` set to `true`)
 #   Memory limit as a string with K, M, G or T suffix, e.g. `2G`
 #
+# @param limit_nofile
+#   Limit max number of opened files for systemd service (requires `service_override_unit_file` set to `true`)
+#
 # @param manage_config_dir
 #   Whether to manage the configuration directory.
 #   When enabled, will remove all unmanaged files from the directory the
@@ -243,6 +246,7 @@ class fluentbit (
   Stdlib::Ensure::Service          $service_ensure,
   String[1]                        $service_name,
   Boolean                          $restart_on_upgrade,
+  Optional[Integer]                $limit_nofile = undef,
 
   Boolean                          $manage_config_dir,
   Boolean                          $manage_data_dir,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -246,7 +246,6 @@ class fluentbit (
   Stdlib::Ensure::Service          $service_ensure,
   String[1]                        $service_name,
   Boolean                          $restart_on_upgrade,
-  Optional[Integer]                $limit_nofile = undef,
 
   Boolean                          $manage_config_dir,
   Boolean                          $manage_data_dir,
@@ -305,6 +304,7 @@ class fluentbit (
   Array[Stdlib::Absolutepath]      $plugins           = [],
   Optional[String[1]]              $memory_max        = undef,
   Optional[Stdlib::Absolutepath]   $log_file          = undef,
+  Optional[Integer]                $limit_nofile      = undef,
   Array[Stdlib::Absolutepath]      $includes          = [],
 ) {
   $pipelines_path = "${config_dir}/${pipelines_dir}"

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -20,9 +20,10 @@ class fluentbit::service {
         notify  => Service[$fluentbit::service_name],
         content => epp('fluentbit/fluentbit.service.epp',
           {
-            'binary_file' => $fluentbit::binary_file,
-            'config_file' => $fluentbit::config_path,
-            'memory_max'  => $fluentbit::memory_max,
+            'binary_file'  => $fluentbit::binary_file,
+            'config_file'  => $fluentbit::config_path,
+            'memory_max'   => $fluentbit::memory_max,
+            'limit_nofile' => $fluentbit::limit_nofile,
           }
         ),
       }

--- a/spec/classes/fluentbit_spec.rb
+++ b/spec/classes/fluentbit_spec.rb
@@ -395,7 +395,7 @@ describe 'fluentbit' do
     let(:params) do
       {
         service_override_unit_file: true,
-        limit_nofile: 65536,
+        limit_nofile: 65_536,
         manage_service: true,
       }
     end

--- a/spec/classes/fluentbit_spec.rb
+++ b/spec/classes/fluentbit_spec.rb
@@ -391,6 +391,26 @@ describe 'fluentbit' do
     }
   end
 
+  context 'with service ulimit -n' do
+    let(:params) do
+      {
+        service_override_unit_file: true,
+        limit_nofile: 65536,
+        manage_service: true,
+      }
+    end
+
+    it {
+      is_expected.to contain_service('fluent-bit')
+        .with_ensure('running')
+    }
+
+    it {
+      is_expected.to contain_systemd__unit_file('fluent-bit.service')
+        .with_content(%r{LimitNOFILE=65536})
+    }
+  end
+
   describe 'with service config via hash' do
     context 'with classic format' do
       let(:params) do

--- a/spec/classes/fluentbit_spec.rb
+++ b/spec/classes/fluentbit_spec.rb
@@ -391,24 +391,46 @@ describe 'fluentbit' do
     }
   end
 
-  context 'with service ulimit -n' do
-    let(:params) do
-      {
-        service_override_unit_file: true,
-        limit_nofile: 65_536,
-        manage_service: true,
+  describe 'with systemd service num files limit' do
+    context 'with service nofile limit' do
+      let(:params) do
+        {
+          service_override_unit_file: true,
+          limit_nofile: 65_536,
+          manage_service: true,
+        }
+      end
+
+      it {
+        is_expected.to contain_service('fluent-bit')
+          .with_ensure('running')
+      }
+
+      it {
+        is_expected.to contain_systemd__unit_file('fluent-bit.service')
+          .with_content(%r{LimitNOFILE=65536})
       }
     end
 
-    it {
-      is_expected.to contain_service('fluent-bit')
-        .with_ensure('running')
-    }
+    context 'with soft and hard limit' do
+      let(:params) do
+        {
+          service_override_unit_file: true,
+          limit_nofile: '8192:16384',
+          manage_service: true,
+        }
+      end
 
-    it {
-      is_expected.to contain_systemd__unit_file('fluent-bit.service')
-        .with_content(%r{LimitNOFILE=65536})
-    }
+      it {
+        is_expected.to contain_service('fluent-bit')
+          .with_ensure('running')
+      }
+
+      it {
+        is_expected.to contain_systemd__unit_file('fluent-bit.service')
+          .with_content(%r{LimitNOFILE=8192:16384})
+      }
+    end
   end
 
   describe 'with service config via hash' do

--- a/templates/fluentbit.service.epp
+++ b/templates/fluentbit.service.epp
@@ -14,6 +14,9 @@ Restart=always
 <%- if $memory_max { -%>
 MemoryMax=<%= $memory_max %>
 <%- } -%>
+<%- if $limit_nofile { -%>
+LimitNOFILE=<%= $limit_nofile %>
+<%- } -%>
 
 [Install]
 WantedBy=multi-user.target

--- a/types/nofilelimit.pp
+++ b/types/nofilelimit.pp
@@ -1,0 +1,5 @@
+# systemd nofile limit, e.g 1024:4096 or simply 2048 (same soft and hard limit)
+type Fluentbit::NoFileLimit = Variant[
+  Integer[-1],
+  Pattern['^(infinity|\d+(:(infinity|\d+))?)$']
+]


### PR DESCRIPTION
Limits max number of opened file descriptors for systemd service.