### PR TITLE
use syslog-rfc5424 defined upstream

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -109,9 +109,9 @@ fluentbit::parsers:
 
   syslog-rfc5424:
     format: regex
-    regex: '^\<(?<pri>[0-9]{1,5})\>1 (?<time>[^ ]+) (?<host>[^ ]+) (?<ident>[^ ]+) (?<pid>[-0-9]+) (?<msgid>[^ ]+) (?<extradata>(\[(.*)\]|-)) (?<message>.+)$'
+    regex: '^\<(?<pri>[0-9]{1,5})\>1 (?<time>[^ ]+) (?<host>[^ ]+) (?<ident>[^ ]+) (?<pid>[-0-9]+) (?<msgid>[^ ]+) (?<extradata>(\[(.*?)\]|-)) (?<message>.+)$'
     time_key: time
-    time_format: '%Y-%m-%dT%H:%M:%S.%L'
+    time_format: '%Y-%m-%dT%H:%M:%S.%L%z'
     time_keep: true
 
   syslog-rfc3164-local:


### PR DESCRIPTION
The timezone is not defined, and an extra char in the regex

Updated to use upstream config:
https://github.com/fluent/fluent-bit/blob/master/conf/parsers.conf
