### PR TITLE
key_group support for multiline parser

### DIFF
--- a/templates/parsers.conf.epp
+++ b/templates/parsers.conf.epp
@@ -42,6 +42,9 @@
 <% if $parser['key_content'] { -%>
     Key_content   <%= $parser['key_content'] %>
 <% } -%>
+<% if $parser['key_group'] { -%>
+    Key_group     <%= $parser['key_group'] %>
+<% } -%>
 <% if $parser['flush_timeout'] { -%>
     Flush_timeout <%= $parser['flush_timeout'] %>
 <% } -%>

--- a/types/multilineparser.pp
+++ b/types/multilineparser.pp
@@ -7,5 +7,6 @@ type Fluentbit::MultilineParser = Hash[String, Struct[{
                           }]],
   Optional[parser]        => String[1],
   Optional[key_content]   => String[1],
+  Optional[key_group]     => String[1],
   Optional[flush_timeout] => Integer,
 }]]


### PR DESCRIPTION
As described in this documentation, the parameter `key_group` can be used:

>For an incoming structured message, specify the key used as a grouping identifier. Lines with different values for this key are treated as separate streams. For example, Docker and CRI logs use the stream field to distinguish stdout from stderr.

https://docs.fluentbit.io/manual/data-pipeline/parsers/multiline-parsing

My use case in in parsing php debug log forwarded to rsyslog, where an app can generate a multiline logs.  I’m not sure it could really happen, but I want to make sure this case is properly filtered just in case, and use the PID as distinguisher.

```
Aug 13 13:06:06 vagrant-test php[32511]: Multiline example:
Aug 13 13:06:06 vagrant-test php[32511]: * First line
Aug 13 13:06:06 vagrant-test php[32511]: * Second line
Aug 13 13:06:06 vagrant-test php[32722]: Another multiline example:
Aug 13 13:06:06 vagrant-test php[32722]: ** First line
Aug 13 13:06:06 vagrant-test php[32511]: * Third line
Aug 13 13:06:06 vagrant-test php[32511]: 
Aug 13 13:06:06 vagrant-test php[32722]: ** Second line
Aug 13 13:06:06 vagrant-test php[32722]: ** Third line
Aug 13 13:06:06 vagrant-test php[32722]: 
```

```
    class { 'fluentbit':
      [...]
      multiline_parsers          => {
        'multiline_example' => {
          'type'          => 'regex',
          'key_content'   => 'message',
          'key_group'     => 'pid',
          'flush_timeout' => 2000,
          'rules'         => [
            { 'state' => 'start_state', 'regex' => '/^Multiline example:/', 'next_state'=> 'cont' },
            { 'state' => 'start_state', 'regex' => '/^Another multiline example:/', 'next_state'=> 'cont' },
            { 'state' => 'cont', 'regex' => '/^.+$/', 'next_state'=> 'cont' },
          ],
        },
      },

```

```
[MULTILINE_PARSER]
    Name          multiline_example
    Type          regex
    Key_content   message
    Key_group     pid
    Flush_timeout 2000
    Rule  "start_state" "/^Multiline example:/" "cont"
    Rule  "start_state" "/^Another multiline example:/" "cont"
    Rule  "cont" "/^.+$/" "cont"
```